### PR TITLE
Docs

### DIFF
--- a/docs/source/modules/contrib.rst
+++ b/docs/source/modules/contrib.rst
@@ -88,3 +88,17 @@ Explainer
 
 .. automodule:: torch_geometric.contrib.explain
     :members:
+
+FLAG Data Augmentation
+----------------------
+
+.. currentmodule:: torch_geometric.contrib.flag
+
+.. autosummary::
+    :nosignatures:
+    {% for cls in torch_geometric.contrib.flag.classes %}
+      {{ cls }}
+    {% endfor %}
+
+.. automodule:: torch_geometric.contrib.flag
+    :members:

--- a/torch_geometric/contrib/__init__.py
+++ b/torch_geometric/contrib/__init__.py
@@ -4,6 +4,7 @@ import torch_geometric.contrib.transforms  # noqa
 import torch_geometric.contrib.datasets  # noqa
 import torch_geometric.contrib.nn  # noqa
 import torch_geometric.contrib.explain  # noqa
+import torch_geometric.contrib.flag  # noqa
 
 warnings.warn(
     "'torch_geometric.contrib' contains experimental code and is subject to "

--- a/torch_geometric/contrib/flag/flag.py
+++ b/torch_geometric/contrib/flag/flag.py
@@ -13,8 +13,8 @@ class FLAG(torch.nn.Module):
     <https://arxiv.org/pdf/2010.09891.pdf>`_ paper.
 
     FLAG is a model and task free data augmentation strategy for graphs. It
-    runs `n_ascent_step` forward and backward passes, perturbing the node
-    features, performing gradient ascent on this perturbation, and
+    runs :code:`n_ascent_step` forward and backward passes, perturbing the
+    node features, performing gradient ascent on this perturbation, and
     accumulating the gradients with respect to the model parameters. At the
     end of the steps, the model parameters are updated with these accumulated
     gradients.
@@ -22,7 +22,8 @@ class FLAG(torch.nn.Module):
     FLAG can be used in node classification, link prediction, and graph
     classification. However, this implementation is only meant for data with
     continuous node features (while the original paper handles discrete node
-    features, it does so through changes to the model's `forward` function).
+    features, it does so through changes to the model's :code:`forward`
+    function).
 
     Args:
         model (torch.nn.Module): The GNN module to train.
@@ -61,8 +62,8 @@ class FLAG(torch.nn.Module):
     ) -> tuple[torch.nn.Module, torch.Tensor]:
         """
         Perform the FLAG forward and backward passes. Note that users should
-        not invoke `loss.backward()` or `optimizer.step()` externally to this
-        function in their epoch loop.
+        not invoke :code:`loss.backward()` or :code:`optimizer.step()`
+        externally to this function in their epoch loop.
 
         Args:
             x (torch.Tensor): Node feature matrix with shape

--- a/torch_geometric/contrib/flag/flag.py
+++ b/torch_geometric/contrib/flag/flag.py
@@ -1,4 +1,5 @@
 import numbers
+from typing import List
 
 import torch
 
@@ -44,7 +45,7 @@ class FLAG(torch.nn.Module):
         optimizer: torch.optim.Optimizer,
         loss_fn: torch.nn.Module,
         device: torch.device,
-        callbacks: [FLAGCallback] = [],
+        callbacks: List[FLAGCallback] = [],
     ) -> None:  # None return type as per https://peps.python.org/pep-0484/
         super(FLAG, self).__init__()
 
@@ -57,26 +58,26 @@ class FLAG(torch.nn.Module):
 
     def forward(
         self,
-        x: torch.tensor,
-        edge_index: torch.tensor,
-        y_true: torch.tensor,
-        train_idx: torch.tensor,
+        x: torch.Tensor,
+        edge_index: torch.Tensor,
+        y_true: torch.Tensor,
+        train_idx: torch.Tensor,
         step_size: float,
         n_ascent_steps: int = 3,
-    ) -> tuple[torch.nn.Module, torch.tensor]:
+    ) -> tuple[torch.nn.Module, torch.Tensor]:
         """
         Perform the FLAG forward and backward passes. Note that users should
         not invoke loss.backward() or optimizer.step() externally to this
         function in their epoch loop.
 
         Args:
-            x (torch.tensor): Node feature matrix with shape
+            x (torch.Tensor): Node feature matrix with shape
                 [num_nodes, num_node_features].
-            edge_index (torch.tensor): Graph connectivity in COO format with
+            edge_index (torch.Tensor): Graph connectivity in COO format with
                 shape [2, num_edges].
-            y_true (torch.tensor): Graph-level, node-level, or edge-level
+            y_true (torch.Tensor): Graph-level, node-level, or edge-level
                 ground-truth labels.
-            train_idx (torch.tensor): Indices of training data.
+            train_idx (torch.Tensor): Indices of training data.
             step_size (float): The step size to take during the gradient
                 ascent on the perturbation. This is also used as the ranges
                 when initializing the perturbation.
@@ -86,7 +87,7 @@ class FLAG(torch.nn.Module):
         Returns:
             self.loss (torch.nn.Module): The loss after the final iteration
                 of the FLAG algorithm.
-            out (torch.tensor): The model output on the perturbed inputs from
+            out (torch.Tensor): The model output on the perturbed inputs from
                 the last iteration of the FLAG algorithm.
         """
 

--- a/torch_geometric/contrib/flag/flag.py
+++ b/torch_geometric/contrib/flag/flag.py
@@ -109,7 +109,7 @@ class FLAG(torch.nn.Module):
         # This example does not assume that the model forward function has a
         #   `perturb` argument
 
-        training_labels = y_true[train_idx]
+        training_labels = y_true.squeeze(1)[train_idx]
 
         self.model.train()
         self.optimizer.zero_grad()

--- a/torch_geometric/contrib/flag/flag.py
+++ b/torch_geometric/contrib/flag/flag.py
@@ -4,11 +4,44 @@ import torch
 
 from .flag_callback import FLAGCallback
 
+
 class FLAG(torch.nn.Module):
+    """
+    The Free Large-scale Adversarial Augmentation on Graphs (FLAG) algorithm
+    from the `Robust Optimization as Data Augmentation for Large-scale Graphs
+    <https://arxiv.org/pdf/2010.09891.pdf>`_ paper.
+
+    FLAG is a model and task free data augmentation strategy for graphs. It
+    runs `n_ascent_step` forward and backward passes, perturbing the node
+    features, performing gradient ascent on this perturbation, and
+    accumulating the gradients with respect to the model parameters. At the
+    end of the steps, the model parameters are updated with these accumulated
+    gradients.
+
+    FLAG can be used in node classification, link prediction, and graph
+    classification. However, this implementation is only meant for data with
+    continuous node features (while the original paper handles discrete node
+    features, it does so through changes to the model's `forward` function).
+
+    .. note::
+        For examples of using FLAG in a training loop, see
+        `examples/contrib/flag.py
+        <https://github.com/pyg-team/pytorch_geometric/blob/master/examples/
+        contrib/flag.py>`_
+
+    Args:
+        model (torch.nn.Module): The GNN module to train.
+        optimizer (torch.optim.Optimizer): The optimizer object.
+        loss_fn (torch.nn.Module): The loss function that is used for
+            calculating the gradients.
+        device (torch.device): The device to use.
+        callbacks ([FLAGCallback]): List of callbacks to apply during FLAG
+            algorithm.
+    """
     def __init__(
         self,
         model: torch.nn.Module,
-        optimizer: torch.nn.Module,
+        optimizer: torch.optim.Optimizer,
         loss_fn: torch.nn.Module,
         device: torch.device,
         callbacks: [FLAGCallback] = [],
@@ -31,6 +64,32 @@ class FLAG(torch.nn.Module):
         step_size: float,
         n_ascent_steps: int = 3,
     ) -> tuple[torch.nn.Module, torch.tensor]:
+        """
+        Perform the FLAG forward and backward passes. Note that users should
+        not invoke loss.backward() or optimizer.step() externally to this
+        function in their epoch loop.
+
+        Args:
+            x (torch.tensor): Node feature matrix with shape
+                [num_nodes, num_node_features].
+            edge_index (torch.tensor): Graph connectivity in COO format with
+                shape [2, num_edges].
+            y_true (torch.tensor): Graph-level, node-level, or edge-level
+                ground-truth labels.
+            train_idx (torch.tensor): Indices of training data.
+            step_size (float): The step size to take during the gradient
+                ascent on the perturbation. This is also used as the ranges
+                when initializing the perturbation.
+            n_ascent_steps (int): The number of forward and backward passes
+                to take. Note that the FLAG paper uses 3 for experiments.
+
+        Returns:
+            self.loss (torch.nn.Module): The loss after the final iteration
+                of the FLAG algorithm.
+            out (torch.tensor): The model output on the perturbed inputs from
+                the last iteration of the FLAG algorithm.
+        """
+
         if not isinstance(n_ascent_steps, int) or n_ascent_steps <= 0:
             raise ValueError(f"Invalid n_ascent_steps: {n_ascent_steps}." +
                              " n_ascent_steps should be a positive integer.")
@@ -42,41 +101,18 @@ class FLAG(torch.nn.Module):
         # Code below adapted from:
         #   https://github.com/devnkong/FLAG/blob/main/deep_gcns_torch
         #     /examples/ogb/ogbn_arxiv/main.py#L56
-        #
-        # This example does not assume that the model forward function has a
-        #   `perturb` argument
-        # forward = lambda perturb : model(x+perturb, edge_index)[train_idx]
-        # model_forward = (model, forward)
-
-        # TODO
-        # Tyler, did you mean to have .squeeze(1)??
-        training_labels = y_true[train_idx]
-
-        # loss, out = flag(model_forward, x.shape, target,
-        #   args, optimizer, device, F.nll_loss)
-        #
-        # return loss.item()
-
-        ########################################################
-
-        # Code below adapted from:
+        #   and
         #   https://github.com/devnkong/FLAG/blob/main/deep_gcns_torch
         #     /examples/ogb/attacks.py
         #
-        # model, forward = model_forward
+        # This example does not assume that the model forward function has a
+        #   `perturb` argument
+
+        training_labels = y_true[train_idx]
+
         self.model.train()
         self.optimizer.zero_grad()
 
-        # perturb = torch.FloatTensor(*x.shape).uniform_(
-        #   -args.step_size, args.step_size).to(self.device)
-
-        # perturb = torch.FloatTensor(*x.shape).uniform_(
-        #     -step_size, step_size).to(self.device)
-        # perturb.requires_grad_()
-
-        # TODO
-        # If this implementation doesn't work as we expect, try changing
-        # this back to to original implementation using tensor.uniform_()
         self.perturb = torch.nn.Parameter(
             torch.zeros(
                 *x.shape,
@@ -86,36 +122,37 @@ class FLAG(torch.nn.Module):
 
         [c.on_ascent_step_begin(0, None) for c in self.callbacks]
 
-        # out = forward(perturb)
         out = self.model(x + self.perturb, edge_index)[train_idx]
         self.loss = self.loss_fn(out, training_labels)
-
-        # loss /= args.m
         self.loss /= n_ascent_steps
 
-        [c.on_ascent_step_end(0, self.loss, self.perturb) for c in self.callbacks]
+        [
+            c.on_ascent_step_end(0, self.loss, self.perturb)
+            for c in self.callbacks
+        ]
 
-        # for _ in range(args.m - 1):
         for i in range(n_ascent_steps - 1):
+
             [c.on_ascent_step_begin(i + 1, self.loss) for c in self.callbacks]
 
             self.loss.backward()
-            # perturb_data = perturb.detach() + args.step_size *
-            #   torch.sign(perturb.grad.detach())
+
+            # Update the perturbation at each step using gradient ascent
             perturb_data = self.perturb.detach() + step_size * torch.sign(
                 self.perturb.grad.detach())
             self.perturb.data = perturb_data.data
             self.perturb.grad[:] = 0
 
-            # out = forward(perturb)
+            # Calculate the loss on the perturbed input
             out = self.model(x + self.perturb, edge_index)[train_idx]
             self.loss = self.loss_fn(out, training_labels)
 
-            # loss /= args.m
             self.loss /= n_ascent_steps
 
-            [c.on_ascent_step_end(i + 1, self.loss, self.perturb) for c in self.callbacks]
-
+            [
+                c.on_ascent_step_end(i + 1, self.loss, self.perturb)
+                for c in self.callbacks
+            ]
 
         [c.on_optimizer_step_begin(self.loss) for c in self.callbacks]
 
@@ -135,8 +172,8 @@ class FLAG(torch.nn.Module):
 
     def get_model(self) -> torch.nn.Module:
         """
-        returns: a reference to the underlying model that was trained by
-                 the FLAG module.
+        Returns:
+            self.model (torch.nn.Module): a reference to the underlying model
+                that was trained by the FLAG module.
         """
         return self.model
-

--- a/torch_geometric/contrib/flag/flag.py
+++ b/torch_geometric/contrib/flag/flag.py
@@ -84,11 +84,11 @@ class FLAG(torch.nn.Module):
             n_ascent_steps (int): The number of forward and backward passes
                 to take. Note that the FLAG paper uses 3 for experiments.
 
-        Returns:
-            self.loss (torch.nn.Module): The loss after the final iteration
-                of the FLAG algorithm.
-            out (torch.Tensor): The model output on the perturbed inputs from
-                the last iteration of the FLAG algorithm.
+        :returns:
+            - self.loss (torch.nn.Module) - The loss after the final \
+                iteration of the FLAG algorithm.
+            - out (torch.Tensor) - The model output on the perturbed inputs \
+                from the last iteration of the FLAG algorithm.
         """
 
         if not isinstance(n_ascent_steps, int) or n_ascent_steps <= 0:
@@ -173,8 +173,8 @@ class FLAG(torch.nn.Module):
 
     def get_model(self) -> torch.nn.Module:
         """
-        Returns:
-            self.model (torch.nn.Module): a reference to the underlying model
-                that was trained by the FLAG module.
+        :returns:
+            - self.model (torch.nn.Module): a reference to the underlying \
+                model that was trained by the FLAG module.
         """
         return self.model

--- a/torch_geometric/contrib/flag/flag_callback.py
+++ b/torch_geometric/contrib/flag/flag_callback.py
@@ -1,14 +1,71 @@
+from typing import Optional
+
+import torch
+
+
 class FLAGCallback:
-  def on_ascent_step_begin(self, step_index, loss):
-    pass
+    """
+    Base class for callbacks to use in order to hook into the various stages
+    of the model training with the
+    `FLAG data augmentation strategy
+    <https://github.com/pyg-team/pytorch_geometric/blob/master/
+    torch_geometric/contrib/flag/flag.py>`_.
 
-  def on_ascent_step_end(self, step_index, loss, perturb_data):
-    pass
+    To create a custom callback, subclass
+    `torch_geometric.contrib.flag.FLAGCallback` and override the method
+    associated with the stage of interest.
+    """
+    def on_ascent_step_begin(self, step_index: int,
+                             loss: Optional[torch.nn.Module]):
+        """
+        Called at the start of an ascent step.
 
-  def on_optimizer_step_begin(self, loss):
-    pass
+        Subclasses should override for any actions to run. This function
+        should only be called during TRAIN mode.
 
-  def on_optimizer_step_end(self, loss):
-    pass
+        Args:
+            step_index (int): The index of step.
+            loss (Optional[torch.nn.Module]): The loss before the ascent
+                step. Will be None before the first ascent step.
+        """
+        pass
 
+    def on_ascent_step_end(self, step_index: int, loss: torch.nn.Module,
+                           perturb_data: torch.nn.Parameter):
+        """
+        Called at the end of an ascent step.
 
+        Subclasses should override for any actions to run. This function
+        should only be called during TRAIN mode.
+
+        Args:
+            step_index (int): The index of step.
+            loss (torch.nn.Module): The loss after the ascent step.
+            perturb_data (torch.nn.Parameter): The tensor containing the input
+                perturbations after the ascent step.
+        """
+        pass
+
+    def on_optimizer_step_begin(self, loss: torch.nn.Module):
+        """
+        Called at the start of an optimizer step.
+
+        Subclasses should override for any actions to run. This function
+        should only be called during TRAIN mode.
+
+        Args:
+            loss (torch.nn.Module): The loss after the ascent step.
+        """
+        pass
+
+    def on_optimizer_step_end(self, loss: torch.nn.Module):
+        """
+        Called at the end of an optimizer step.
+
+        Subclasses should override for any actions to run. This function
+        should only be called during TRAIN mode.
+
+        Args:
+            loss (torch.nn.Module): The loss after the ascent step.
+        """
+        pass


### PR DESCRIPTION
Made changes to allow the FLAG and FLAGCallback classes to appear in the docs.

To generate and view the docs:
1. Install Sphinx: `pip install git+https://github.com/pyg-team/pyg_sphinx_theme.git`
2. cd into the docs folder: `cd docs`
3. Make the docs: `make html`
4. Open `docs/build/html/index.html` in a browser. The FLAG docs are in the `torch_geometric.contrib` section. 

